### PR TITLE
emacs-setup-instructions -- add from scratch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,17 @@ root@6956ef978d70:/app# realsense-viewer
 jedmiston@je-hp: $ xhost -local:root
 non-network local connections being removed from access control list
 ```
+
+# Emacs
+* emacs.el contains a config file for environments.
+* From a quick standpoint, in early 2021 this is what worked for me:
+* `sudo apt-get install emacs python3 python-is-python3`
+* Move start file to emacs home. 
+* `cp emacs.el ~/.`
+* Download Anaconda, set up `conda create -n portfolio python==3.8`
+* Then load the environment and do `(portfolio)$ pip install jedi flake8 yapf autopep8 black rope`
+* In emacs session, install MELPA packages using `M-x list-packages` and then searching for and selecting
+* `elpy`
+* `virtualenvwrapper`
+* `py-autopep8`
+* You can use in emacs, `M-x elpy-config` to list out the configuration for the loaded environments. 

--- a/emacs.el
+++ b/emacs.el
@@ -11,7 +11,7 @@
 
 (setq inhibit-startup-message t) ;; hide the startup message
 ;;(custom-set-variables
-;; (pyvenv-activate "/Users/johnedmiston/anaconda3/envs/myco")
+
 ;; https://github.com/jorgenschaefer/elpy
 (package-initialize)
 (elpy-enable)
@@ -22,9 +22,9 @@
 ;; note that setting `venv-location` is not necessary if you
 ;; use the default location (`~/.virtualenvs`), or if the
 ;; the environment variable `WORKON_HOME` points to the right place
-(setq venv-location "/Users/johnedmiston/anaconda3/envs/myco")
+(setq venv-location "/Users/johnedmiston/anaconda3/envs/portfolio")
 
-(pyvenv-activate "/Users/johnedmiston/anaconda3/envs/myco")
+(pyvenv-activate "/Users/johnedmiston/anaconda3/envs/portfolio")
 ;; Enable Flycheck
 (when (require 'flycheck nil t)
   (setq elpy-modules (delq 'elpy-module-flymake elpy-modules))


### PR DESCRIPTION
- for Ubuntu 20.04, how to set up elpy-config and the dev env.